### PR TITLE
[FEAT] 서치바로 도시 실시간 검색

### DIFF
--- a/TravelMagazineProject/Base.lproj/Main.storyboard
+++ b/TravelMagazineProject/Base.lproj/Main.storyboard
@@ -194,7 +194,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="mAr-D7-gqU">
-                                <rect key="frame" x="0.0" y="134" width="393" height="684"/>
+                                <rect key="frame" x="0.0" y="190" width="393" height="628"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="rwj-Ny-91a">
                                     <size key="itemSize" width="128" height="128"/>
@@ -214,7 +214,7 @@
                                 </cells>
                             </collectionView>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ZHv-e5-xXM">
-                                <rect key="frame" x="20" y="103" width="353" height="32"/>
+                                <rect key="frame" x="20" y="159" width="353" height="32"/>
                                 <segments>
                                     <segment title="모두"/>
                                     <segment title="국내"/>
@@ -224,22 +224,33 @@
                                     <action selector="segmentClicked:" destination="j0G-Dg-3AH" eventType="valueChanged" id="afQ-34-MKA"/>
                                 </connections>
                             </segmentedControl>
+                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="vkn-n7-z2R">
+                                <rect key="frame" x="0.0" y="103" width="393" height="56"/>
+                                <textInputTraits key="textInputTraits"/>
+                                <connections>
+                                    <outlet property="delegate" destination="j0G-Dg-3AH" id="pjb-bd-RDC"/>
+                                </connections>
+                            </searchBar>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="BUc-gB-6DB"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="BUc-gB-6DB" firstAttribute="trailing" secondItem="mAr-D7-gqU" secondAttribute="trailing" id="2Rc-DL-wVR"/>
-                            <constraint firstItem="ZHv-e5-xXM" firstAttribute="top" secondItem="BUc-gB-6DB" secondAttribute="top" id="8yz-Nf-yDe"/>
+                            <constraint firstItem="vkn-n7-z2R" firstAttribute="trailing" secondItem="BUc-gB-6DB" secondAttribute="trailing" id="IjO-ZV-mRV"/>
+                            <constraint firstItem="vkn-n7-z2R" firstAttribute="leading" secondItem="BUc-gB-6DB" secondAttribute="leading" id="Qkk-Vh-bo7"/>
                             <constraint firstItem="BUc-gB-6DB" firstAttribute="trailing" secondItem="ZHv-e5-xXM" secondAttribute="trailing" constant="20" id="T25-n3-B7w"/>
                             <constraint firstItem="BUc-gB-6DB" firstAttribute="bottom" secondItem="mAr-D7-gqU" secondAttribute="bottom" id="ebw-Bp-z5m"/>
                             <constraint firstItem="mAr-D7-gqU" firstAttribute="leading" secondItem="BUc-gB-6DB" secondAttribute="leading" id="iCh-LG-AMW"/>
                             <constraint firstItem="mAr-D7-gqU" firstAttribute="top" secondItem="ZHv-e5-xXM" secondAttribute="bottom" id="jNQ-3F-kcp"/>
+                            <constraint firstItem="ZHv-e5-xXM" firstAttribute="top" secondItem="vkn-n7-z2R" secondAttribute="bottom" id="rxJ-Vb-THr"/>
+                            <constraint firstItem="vkn-n7-z2R" firstAttribute="top" secondItem="BUc-gB-6DB" secondAttribute="top" id="w4F-ju-Ugi"/>
                             <constraint firstItem="ZHv-e5-xXM" firstAttribute="leading" secondItem="BUc-gB-6DB" secondAttribute="leading" constant="20" id="wxf-d7-2d5"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="mIa-V1-byO"/>
                     <connections>
                         <outlet property="cityCollectionView" destination="mAr-D7-gqU" id="46t-Iv-f2N"/>
+                        <outlet property="citySearchBar" destination="vkn-n7-z2R" id="16n-yG-SRs"/>
                         <outlet property="domesticSegment" destination="ZHv-e5-xXM" id="nVy-Yj-fiz"/>
                     </connections>
                 </viewController>

--- a/TravelMagazineProject/RootIsViewController/CityViewController.swift
+++ b/TravelMagazineProject/RootIsViewController/CityViewController.swift
@@ -21,6 +21,7 @@ protocol ViewControllerSetting {
 
 class CityViewController: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource {
     
+    @IBOutlet weak var citySearchBar: UISearchBar!
     @IBOutlet var domesticSegment: UISegmentedControl!
     @IBOutlet weak var cityCollectionView: UICollectionView!
     
@@ -34,6 +35,8 @@ class CityViewController: UIViewController, UICollectionViewDelegate, UICollecti
     let verticalSpacing: CGFloat = 10
     let horizontalSpacing: CGFloat = 20
     let inset: CGFloat = 20
+    
+    var currentSegmentIdx: Int = 0 // 서치바 위해 현재 세그먼트위치 저장
     
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return filterdCity.count
@@ -58,26 +61,39 @@ class CityViewController: UIViewController, UICollectionViewDelegate, UICollecti
 
         cityCollectionView.dataSource = self
         cityCollectionView.delegate = self
+        citySearchBar.delegate = self
         
         width = (UIScreen.main.bounds.width - (inset * 2 + horizontalSpacing)) / 2
         
         // 레이아웃 잡기
         cityCollectionView.collectionViewLayout = settingCollectionViewLayout(cellWidth: width)
+        
+//        designElements()
     }
     
+    // 세그멘트 선택 시
     @IBAction func segmentClicked(_ sender: UISegmentedControl) {
+        currentSegmentIdx = sender.selectedSegmentIndex
         // 눌린 세그먼트의 TravelLocation타입
-        let domesticTravel = domestic[sender.selectedSegmentIndex]
+        let domesticTravel = domestic[currentSegmentIdx]
+        // 상태에 따라서 filteredCity 갱신
+        filterCity(state: domesticTravel)
         
-        if domesticTravel == .local {
+        cityCollectionView.reloadData() // 데이터 변경했으니 다시 로딩
+        
+        // 세그먼트가 클릭되면 서치바의 값이 바뀔떄 호출되는 함수를 다시 호출해야한다.
+        searchBar(citySearchBar, textDidChange: citySearchBar.text!)
+    }
+    
+    // 현재 세그먼트에 나와야 할 모든 CityList 저장
+    func filterCity(state: TravelLocation) {
+        if state == .local {
             filterdCity = city.filter({$0.domestic_travel})
-        } else if domesticTravel == .abroad {
+        } else if state == .abroad {
             filterdCity = city.filter({!$0.domestic_travel})
         } else {
             filterdCity = city
         }
-        
-        cityCollectionView.reloadData() // 데이터 변경했으니 다시 로딩
     }
 }
 
@@ -100,3 +116,21 @@ extension CityViewController: ViewControllerSetting {
         return layout
     }
 }
+
+extension CityViewController: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        if searchText == "" {
+            // 문자열이 ""이 되면 처음의 상태로 다시 되돌려 주기
+            filterCity(state: domestic[currentSegmentIdx])
+            cityCollectionView.reloadData()
+            return
+        }
+        filterCity(state: domestic[currentSegmentIdx]) // filteredCity가 다시 설정된다.(바로 아래 코드에서 잘 작동할 수 있게 된다.)
+        // 만약 위의 코드가 없다면 어떤 세그먼트에 계속 있는 상태에서 문자열의 변화를 줬을 때 이전 검색기록에서 다시 필터를 하기 떄문에
+        // 태초의 상태로 돌려주어야 한다.
+        filterdCity = filterdCity.filter{"\($0.city_name) + \($0.city_english_name) + \($0.city_explain)".contains(searchText)}
+        
+        cityCollectionView.reloadData()
+    }
+}
+


### PR DESCRIPTION
## 🚀관련 이슈
- close #4 

## 💎작업 내용
- 도시 실시간 검색일 가능하도록
- 문자를 입력할떄마다 검색갱신



## 📸 스크린샷
<img  width="30%" src="https://github.com/nhyeonjeong/TravelMagazineProject/assets/102401977/a0cb1d85-5733-406a-8c12-ef3d4c414c1d"/> 
<img  width="30%" src="https://github.com/nhyeonjeong/TravelMagazineProject/assets/102401977/08ed18cd-8d00-4317-9582-c483f33dac0a"/> 
<img  width="30%" src="https://github.com/nhyeonjeong/TravelMagazineProject/assets/102401977/8ed7553f-a1c7-4053-9416-f651fbcd3564"/> 

## ⭐️참고 사항
- contains 사용
- UISearchBarDelegate프로토콜 
- func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) 사용하면 text부분이 바뀔떄마다 호출된다.
