### PR TITLE
[BUG] 검색기능에서 대소문자, 공백, 콤마 에 상관없이 검색되도록 

### DIFF
--- a/TravelMagazineProject/Base.lproj/Main.storyboard
+++ b/TravelMagazineProject/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="mIt-kz-qgV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Dzb-oZ-CBz">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
@@ -318,7 +318,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGrayColor">
-            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/TravelMagazineProject/RootIsViewController/CityViewController.swift
+++ b/TravelMagazineProject/RootIsViewController/CityViewController.swift
@@ -96,12 +96,13 @@ class CityViewController: UIViewController, UICollectionViewDelegate, UICollecti
         }
     }
     
-    /// 받은 스트링을 ,빼고 다시 문자열로 반환하는 함수
+    /// 받은 스트링을 ,와 공백 빼고 다시 문자열로 반환하는 함수
     func duplicateComma(string: String) -> String {
-        let newString = string.split(separator: ",").joined() // 배열 반환
+        // 공백이 2칸 이상이어도 separator에서 잘 걸러준다
+        let newString = string.split(separator: [",", " "]).joined() // 배열 반환
         print("string: \(string)")
         print("newString: \(newString)")
-        return newString
+        return newString // 공백이 있으면 제거해서 반환
     }
 }
 
@@ -136,12 +137,19 @@ extension CityViewController: UISearchBarDelegate {
         filterCity(state: domestic[currentSegmentIdx]) // filteredCity가 다시 설정된다.(바로 아래 코드에서 잘 작동할 수 있게 된다.)
         // 만약 위의 코드가 없다면 어떤 세그먼트에 계속 있는 상태에서 문자열의 변화를 줬을 때 이전 검색기록에서 다시 필터를 하기 떄문에
         // 태초의 상태로 돌려주어야 한다.
+        let text = searchText.split(separator: [",", " "]).joined().trimmingCharacters(in: .whitespaces).lowercased()
         
-        
-        filterdCity = filterdCity.filter{"\($0.city_name) + \($0.city_english_name) + \(duplicateComma(string: $0.city_explain))".contains(searchText)}
+        // 대소문자, 사이 공백, 양쪽 공백, 콤마 고려하지 않는뎅..
+        filterdCity = filterdCity.filter{"\($0.city_name.lowercased()) + \($0.city_english_name.lowercased()) + \(duplicateComma(string: $0.city_explain).lowercased())".trimmingCharacters(in: .whitespaces).contains(text)}
         
         cityCollectionView.reloadData()
     }
 }
 
-//방콕파타야
+////방콕파타야
+////bangkok
+////토나\두
+//
+//사카교토
+//고베
+//나라

--- a/TravelMagazineProject/RootIsViewController/CityViewController.swift
+++ b/TravelMagazineProject/RootIsViewController/CityViewController.swift
@@ -25,7 +25,7 @@ class CityViewController: UIViewController, UICollectionViewDelegate, UICollecti
     @IBOutlet var domesticSegment: UISegmentedControl!
     @IBOutlet weak var cityCollectionView: UICollectionView!
     
-    // [.all, .local, /abroad]리스트
+    // [.all, .local, .abroad]리스트
     let domestic = TravelLocation.allCases
     
     let city: [City] = CityInfo().city
@@ -95,6 +95,14 @@ class CityViewController: UIViewController, UICollectionViewDelegate, UICollecti
             filterdCity = city
         }
     }
+    
+    /// 받은 스트링을 ,빼고 다시 문자열로 반환하는 함수
+    func duplicateComma(string: String) -> String {
+        let newString = string.split(separator: ",").joined() // 배열 반환
+        print("string: \(string)")
+        print("newString: \(newString)")
+        return newString
+    }
 }
 
 extension CityViewController: ViewControllerSetting {
@@ -128,9 +136,12 @@ extension CityViewController: UISearchBarDelegate {
         filterCity(state: domestic[currentSegmentIdx]) // filteredCity가 다시 설정된다.(바로 아래 코드에서 잘 작동할 수 있게 된다.)
         // 만약 위의 코드가 없다면 어떤 세그먼트에 계속 있는 상태에서 문자열의 변화를 줬을 때 이전 검색기록에서 다시 필터를 하기 떄문에
         // 태초의 상태로 돌려주어야 한다.
-        filterdCity = filterdCity.filter{"\($0.city_name) + \($0.city_english_name) + \($0.city_explain)".contains(searchText)}
+        
+        
+        filterdCity = filterdCity.filter{"\($0.city_name) + \($0.city_english_name) + \(duplicateComma(string: $0.city_explain))".contains(searchText)}
         
         cityCollectionView.reloadData()
     }
 }
 
+//방콕파타야

--- a/TravelMagazineProject/RootIsViewController/CityViewController.swift
+++ b/TravelMagazineProject/RootIsViewController/CityViewController.swift
@@ -145,11 +145,3 @@ extension CityViewController: UISearchBarDelegate {
         cityCollectionView.reloadData()
     }
 }
-
-////방콕파타야
-////bangkok
-////토나\두
-//
-//사카교토
-//고베
-//나라


### PR DESCRIPTION
## 🚀관련 이슈 
- close #9 

## 💎작업 내용
- 검색기능에서 대소문자, 공백, 콤마 에 상관없이 검색되도록 

## 📸 스크린샷
<img  width="30%" src="https://github.com/nhyeonjeong/TravelMagazineProject/assets/102401977/24d0bf46-ad72-46e5-ba46-dee5e7e6467e"/>
<img  width="30%" src="https://github.com/nhyeonjeong/TravelMagazineProject/assets/102401977/b6c53280-cf42-4071-b6f3-0f2b374feaf6"/>

## ⭐️참고 사항
- 다른 단어여도 이어지게 검색하면 검색결과가 나오도록 했는데 이게 맞는 기준인지는 모르겠음🤔
- 예를 들어 '콕파타' 라고만 쳐도 '방**콕파타**야'에서 검색돼서 방콕이 결과창에 뜬다.
- 검색구현에서 메서드를 너무 많이 사용해서 코드가 복잡한데 정리를 어떻게 하면 더 잘할 수 있을 지~고민 -> #11 
![스크린샷 2024-01-11 오후 5 37 54](https://github.com/nhyeonjeong/TravelMagazineProject/assets/102401977/65194dab-e016-46f2-ab64-edca4733f57f)

